### PR TITLE
chore: remove deprecated bottle :unneeded

### DIFF
--- a/awsweb.rb
+++ b/awsweb.rb
@@ -3,7 +3,6 @@ class Awsweb < Formula
   desc "awsweb is a tool for hopping between AWS roles with ease"
   homepage "https://github.com/glassechidna/awsweb"
   version "0.1.7"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/glassechidna/awsweb/releases/download/0.1.7/awsweb_0.1.7_Darwin_x86_64.tar.gz"

--- a/dynamo.rb
+++ b/dynamo.rb
@@ -3,7 +3,6 @@ class Dynamo < Formula
   desc "dynamo is a dead-simple CLI for AWS DynamoDB"
   homepage "https://github.com/glassechidna/dynamo"
   version "0.7.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/glassechidna/dynamo/releases/download/0.7.0/dynamo_0.7.0_Darwin_x86_64.tar.gz"

--- a/efsu.rb
+++ b/efsu.rb
@@ -6,7 +6,6 @@ class Efsu < Formula
   desc "efsu is for accessing AWS EFS from your machine without a VPN"
   homepage "https://github.com/glassechidna/efsu"
   version "0.3.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/kms-host-key.rb
+++ b/kms-host-key.rb
@@ -3,7 +3,6 @@ class KmsHostKey < Formula
   desc "kms-host-key is an easy way to give all your EC2 instances SSH host certificates"
   homepage "https://github.com/glassechidna/kms-host-key"
   version "0.1.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/glassechidna/kms-host-key/releases/download/0.1.0/kms-host-key_0.1.0_darwin_amd64.tar.gz"

--- a/stackit.rb
+++ b/stackit.rb
@@ -3,7 +3,6 @@ class Stackit < Formula
   desc "stackit is a cross-platform CloudFormation CLI tool for easy synchronous and idempotent stack updates"
   homepage "https://github.com/glassechidna/stackit"
   version "0.0.40"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/glassechidna/stackit/releases/download/0.0.40/stackit_0.0.40_Darwin_x86_64.tar.gz"

--- a/webpushy.rb
+++ b/webpushy.rb
@@ -3,7 +3,6 @@ class Webpushy < Formula
   desc "webpushy is a CLI for sending and receiving small payloads using web browser push services"
   homepage "https://github.com/glassechidna/webpushy"
   version "0.2.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/glassechidna/webpushy/releases/download/0.2.0/webpushy_0.2.0_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
fixes:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the glassechidna/taps tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/glassechidna/homebrew-taps/stackit.rb:6
```

see https://github.com/goreleaser/goreleaser/pull/2591